### PR TITLE
Assign constellations

### DIFF
--- a/bin/data/stars.frag
+++ b/bin/data/stars.frag
@@ -4,6 +4,7 @@ uniform int frameNo;
 in vec4 varyingColor;
 in float varyingFocus;
 in float varyingMagnitude;
+in float varyingConstellation;
 out vec4 outputColor;
 
 float invertedMagnitude = -1 * varyingMagnitude + 7;
@@ -28,14 +29,22 @@ float twinkle() {
     return 1 + 0.2 * fract(sin(dot(star.xy ,vec2(12.9898,78.233))) * 43758.5453);
 }
 
+float highlightConstellation() {
+    return 1.0 + 10.0 * varyingConstellation;
+}
+
+float highlight() {
+    return step(0.5, varyingConstellation) * 2.0 + step(varyingConstellation, 0.5) * varyingFocus;
+}
+
 void main() {
     float d = distance(vec2(0.5), gl_PointCoord.st) * falloff;
     float i = intensity;
-    vec4 col = star(varyingColor, i, varyingFocus, d);
+    vec4 col = star(varyingColor, i, highlight(), d);
     // float a = smoothstep(0, 3, col.r + col.g + col.b);
     float a = smoothstep(vec3(0), vec3(1), col.rgb).g;
     // float a = length(smoothstep(vec3(0), vec3(1), col.rgb));
-    // a = a / max(1, varyingMagnitude) * (1 + varyingFocus);
-    a = a / (1 + smoothstep(0, 7, varyingMagnitude) * 6) * (1 + varyingFocus);
+    // a = a / max(1, varyingMagnitude) * (1 + highlight());
+    a = a / (1 + smoothstep(0, 7, varyingMagnitude) * 6) * (1 + highlight());
     outputColor = vec4(col.rgb, a) * twinkle();
 }

--- a/bin/data/stars.vert
+++ b/bin/data/stars.vert
@@ -7,10 +7,12 @@ in vec4 position;
 in vec4 color;
 in float magnitude;
 in int lastFocused;
+in float inConstellation;
 
 out vec4 varyingColor;
 out float varyingFocus;
 out float varyingMagnitude;
+out float varyingConstellation;
 
 const float focusDecay = 15.0;
 
@@ -23,5 +25,6 @@ void main() {
     varyingColor = color;
     varyingFocus = focus();
     varyingMagnitude = magnitude;
+    varyingConstellation = clamp(inConstellation, 0.0, 1.0);
     gl_Position = modelViewProjectionMatrix * position;
 }

--- a/globe.vcxproj
+++ b/globe.vcxproj
@@ -180,6 +180,7 @@
     <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\Constellation.cpp" />
     <ClCompile Include="src\GifSaver.cpp" />
     <ClCompile Include="src\main.cpp" />
     <ClCompile Include="src\ofApp.cpp" />
@@ -188,6 +189,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\colorIndex.h" />
+    <ClInclude Include="src\Constellation.h" />
     <ClInclude Include="src\GifSaver.h" />
     <ClInclude Include="src\StarMesh.h" />
     <ClInclude Include="src\ofApp.h" />

--- a/globe.vcxproj.filters
+++ b/globe.vcxproj.filters
@@ -16,6 +16,9 @@
     <ClCompile Include="src\GifSaver.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="src\Constellation.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="src">
@@ -36,6 +39,9 @@
       <Filter>src</Filter>
     </ClInclude>
     <ClInclude Include="src\GifSaver.h">
+      <Filter>src</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Constellation.h">
       <Filter>src</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Constellation.cpp
+++ b/src/Constellation.cpp
@@ -1,0 +1,38 @@
+#include "Constellation.h"
+
+Constellation Constellation::fromStars(vector<StarMesh::StarAddress> stars) {
+	set<size_t> unconnectedStars;
+	size_t currentStar = ofRandom(stars.size());
+	for (size_t i = 0; i < stars.size(); i++) {
+		if (i == currentStar) continue;
+		unconnectedStars.insert(i);
+	}
+	vector<tuple<size_t, size_t>> edgeIndices;
+
+	while (unconnectedStars.size() > 0) {
+		size_t closestStar;
+		float closestDistance = INFINITY;
+
+		for (auto i : unconnectedStars) {
+			glm::vec3 posA = stars[i].position;
+			glm::vec3 posB = stars[currentStar].position;
+			float thisDistance = ofDistSquared(posA.x, posA.y, posA.z, posB.x, posB.y, posB.z);
+			if (thisDistance < closestDistance) {
+				closestStar = i;
+				closestDistance = thisDistance;
+			}
+		}
+
+		unconnectedStars.erase(closestStar);
+		edgeIndices.emplace_back(currentStar, closestStar);
+		currentStar = closestStar;
+	}
+
+	vector<tuple<glm::vec3, glm::vec3>> edges;
+	edges.reserve(edgeIndices.size());
+	for (auto i : edgeIndices) {
+		edges.emplace_back(stars[std::get<0>(i)].position, stars[std::get<1>(i)].position);
+	}
+
+	return Constellation(stars, edges);
+}

--- a/src/Constellation.h
+++ b/src/Constellation.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ofMain.h"
+#include "StarMesh.h"
+
+class Constellation
+{
+public:
+	Constellation(vector<StarMesh::StarAddress> s, vector<tuple<glm::vec3, glm::vec3>> e) : stars(s), edges(e) {};
+
+	static Constellation fromStars(vector<StarMesh::StarAddress> stars);
+
+	vector<StarMesh::StarAddress> stars;
+	vector<tuple<glm::vec3, glm::vec3>> edges;
+};
+
+struct StarCluster {
+	vector<StarMesh::StarAddress> stars;
+};

--- a/src/StarMesh.h
+++ b/src/StarMesh.h
@@ -16,15 +16,28 @@ public:
 		return positions.size();
 	}
 
+	struct StarAddress {
+		size_t meshIndex;
+		size_t starIndex;
+		float magnitude;
+		glm::vec3 position;
+	};
+
+	vector<StarAddress> brightestStarsInFocus(ofCamera &camera, uint64_t frameNo, size_t count);
+	void setConstellation(vector<StarAddress> &stars, size_t thisMesh);
+
 private:
 	vector<glm::vec3> positions;
 	vector<ofFloatColor> colors;
 	vector<float> magnitudes;
 	vector<uint32_t> lastFocus;
+	vector<float> inConstellation;
 
 	GLint lastFocusedLocation;
+	GLint inConstellationLocation;
 	ofBufferObject bufMagnitudes;
 	ofBufferObject bufLastFocus;
+	ofBufferObject bufInConstellation;
 
 	ofFloatColor randomColor;
 	static const size_t NUM_PROBES = 5;

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -44,7 +44,7 @@ void ofApp::setup() {
 		return a["magnitude"] < b["magnitude"];
 	});
 
-	map<string, StarMesh> constellations;
+	map<string, StarMesh> constellationZones;
 	for (auto &const star : stars) {
 		glm::vec3 xyz(star["x"], star["z"], star["y"]); // intentionally swap y/z
 		glm::vec3 pos;
@@ -59,10 +59,10 @@ void ofApp::setup() {
 			findStar("Rigel", rigel, pos, color, star);
 			findStar("Sirius", sirius, pos, color, star);
 
-			constellations[star["con"]].push(pos, magnitude, color);
+			constellationZones[star["con"]].push(pos, magnitude, color);
 		}
 	}
-	for (auto it : constellations) {
+	for (auto it : constellationZones) {
 		//cout << "Constellation " << it.first << " has " << it.second.size() << " stars" << endl;
 		star_meshes.push_back(it.second);
 	}
@@ -135,8 +135,16 @@ void ofApp::draw() {
 	//drawStar(rigel, "Rigel", camera);
 	//drawStar(sirius, "Sirius", camera);
 
-	ofSetColor(255);
+	
+	ofSetColor(120, 120, 180);
 	camera.begin();
+	for (auto &const constellation : constellations) {
+		for (auto &const pair : constellation) {
+			ofDrawLine(std::get<0>(pair), std::get<1>(pair));
+		}
+	}
+
+	ofSetColor(255);
 	starShader.begin();
 	starShader.setUniform1i("frameNo", ofGetFrameNum());
 	for (auto &mesh : star_meshes) {
@@ -284,4 +292,14 @@ void ofApp::snapshotConstellation() {
 	for (size_t meshIndex = 0; meshIndex < star_meshes.size(); meshIndex++) {
 		star_meshes[meshIndex].setConstellation(brightest, meshIndex);
 	}
+
+	// FIXME: bare minimum constellation
+	vector<tuple<glm::vec3, glm::vec3>> edges;
+	edges.reserve(brightest.size() - 1);
+	glm::vec3 center = brightest[ofRandom(brightest.size())].position;
+	for (auto &const star : brightest) {
+		if (star.position == center) continue;
+		edges.emplace_back(center, star.position);
+	}
+	constellations.push_back(edges);
 }

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -139,7 +139,7 @@ void ofApp::draw() {
 	ofSetColor(120, 120, 180);
 	camera.begin();
 	for (auto &const constellation : constellations) {
-		for (auto &const pair : constellation) {
+		for (auto &const pair : constellation.edges) {
 			ofDrawLine(std::get<0>(pair), std::get<1>(pair));
 		}
 	}
@@ -274,8 +274,8 @@ vector<StarMesh::StarAddress> getBrightFocusedStars(ofCamera &camera, size_t cou
 		brightest.begin(),
 		brightest.end(),
 		[](StarMesh::StarAddress &const a, StarMesh::StarAddress &const b) {
-		return a.magnitude < b.magnitude;
-	}
+			return a.magnitude < b.magnitude;
+		}
 	);
 
 	brightest.resize(count);
@@ -293,13 +293,6 @@ void ofApp::snapshotConstellation() {
 		star_meshes[meshIndex].setConstellation(brightest, meshIndex);
 	}
 
-	// FIXME: bare minimum constellation
-	vector<tuple<glm::vec3, glm::vec3>> edges;
-	edges.reserve(brightest.size() - 1);
-	glm::vec3 center = brightest[ofRandom(brightest.size())].position;
-	for (auto &const star : brightest) {
-		if (star.position == center) continue;
-		edges.emplace_back(center, star.position);
-	}
-	constellations.push_back(edges);
+	Constellation c = Constellation::fromStars(brightest);
+	constellations.push_back(c);
 }

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -35,8 +35,17 @@ void ofApp::setup() {
 	glm::vec3 whatev;
 	glm::vec3 mirror(-1.0, 1.0, 1.0);
 
-	map<string, StarMesh> constellations;
+	vector<ofJson> stars;
+	stars.reserve(result.size());
 	for (auto &star : result) {
+		stars.push_back(star);
+	}
+	std::sort(stars.begin(), stars.end(), [](ofJson &const a, ofJson &const b) {
+		return a["magnitude"] < b["magnitude"];
+	});
+
+	map<string, StarMesh> constellations;
+	for (auto &const star : stars) {
 		glm::vec3 xyz(star["x"], star["z"], star["y"]); // intentionally swap y/z
 		glm::vec3 pos;
 		bool b = glm::intersectLineSphere(origin, xyz, origin, r, pos, whatev, whatev, whatev);
@@ -171,6 +180,9 @@ void ofApp::keyReleased(int key) {
 	case ' ':
 		shaderDirty = true;
 		break;
+	case 'c':
+		snapshotConstellation();
+		break;
 	case 'f':
 		ofToggleFullscreen();
 		break;
@@ -237,5 +249,39 @@ void ofApp::reloadShader() {
 			ofLogNotice() << "Shader failed to compile:" << endl << err << endl;
 		}
 		shaderDirty = false;
+	}
+}
+
+vector<StarMesh::StarAddress> getBrightFocusedStars(ofCamera &camera, size_t count, vector<StarMesh> &const star_meshes) {
+	vector<StarMesh::StarAddress> brightest;
+
+	for (size_t i = 0; i < star_meshes.size(); i++) {
+		auto stars = star_meshes[i].brightestStarsInFocus(camera, ofGetFrameNum(), count);
+		for (auto &const star : stars) {
+			brightest.push_back(StarMesh::StarAddress{ i, star.starIndex, star.magnitude, star.position });
+		}
+	}
+
+	std::sort(
+		brightest.begin(),
+		brightest.end(),
+		[](StarMesh::StarAddress &const a, StarMesh::StarAddress &const b) {
+		return a.magnitude < b.magnitude;
+	}
+	);
+
+	brightest.resize(count);
+	return brightest;
+}
+
+void ofApp::snapshotConstellation() {
+	auto brightest = getBrightFocusedStars(camera, 10, star_meshes);
+	//cout << "Brightest";
+	//for (auto &const star : brightest) {
+	//	cout << " " << star.meshIndex << " " << star.starIndex;
+	//}
+	//cout << endl;
+	for (size_t meshIndex = 0; meshIndex < star_meshes.size(); meshIndex++) {
+		star_meshes[meshIndex].setConstellation(brightest, meshIndex);
 	}
 }

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -6,6 +6,7 @@
 #include "OniManager.h"
 #include "StarMesh.h"
 #include "GifSaver.h"
+#include "Constellation.h"
 
 #define FREECAM
 
@@ -38,7 +39,7 @@ class ofApp : public ofBaseApp{
 		glm::vec3 sirius;
 
 		vector<StarMesh> star_meshes;
-		vector<vector<tuple<glm::vec3, glm::vec3>>> constellations;
+		vector<Constellation> constellations;
 
 #ifdef FREECAM
 		ofEasyCam camera;

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -57,4 +57,6 @@ class ofApp : public ofBaseApp{
 		ofImage recordCapture;
 		unsigned int numRecordFrames = 0;
 		GifSaver* imgSaver;
+
+		void snapshotConstellation();
 };

--- a/src/ofApp.h
+++ b/src/ofApp.h
@@ -38,6 +38,7 @@ class ofApp : public ofBaseApp{
 		glm::vec3 sirius;
 
 		vector<StarMesh> star_meshes;
+		vector<vector<tuple<glm::vec3, glm::vec3>>> constellations;
 
 #ifdef FREECAM
 		ofEasyCam camera;


### PR DESCRIPTION
Add functionality that draws procedural constellations into the sky, based on the positions of users on the screen.

* [x] Add function to mark stars as part of a constellation
* [x] Draw lines between stars (least effort to connect all stars with non-intersecting lines)
* [ ] Implement algorithm to make constellation lines look like actual constellations
* Add exclusion zones so new constellations can't be place too close to or on top of others
  * [ ] Define exclusion zones
  * [ ] Only use difference between user map and exclusion zones for constellation creation
* [ ] Implement logic to automatically mark new constellations, instead of being manually triggered